### PR TITLE
Add SHOESTRAP_BASE environment variable

### DIFF
--- a/helpers/default
+++ b/helpers/default
@@ -5,7 +5,11 @@
 ##############################################################################
 
 COOKBOOK_NAME="$(basename $0)"
-DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ -z "SHOESTRAP_BASE" ]; then
+    DIR="$( cd "$( dirname "$0" )" && pwd )"
+else
+    DIR="$SHOESTRAP_BASE"
+fi
 
 #
 # Run a given recipe.


### PR DESCRIPTION
This adds SHOESTRAP_BASE to helpers/default, which
allows the cookbook file to be stored separately from
the rest of the shoestrap stuff, making the shoestrap
directory less cluttered. For example:

Old way:

  (cd /shoestrap && ./test1.book)

New way (with cookbook moved to subdirectory 'books/'):

  (cd /shoestrap && SHOESTRAP_BASE=/shoestrap ./books/test1.book)
