### PR TITLE
Fix reference to $SHOESTRAP_BASE variable.

### DIFF
--- a/helpers/default
+++ b/helpers/default
@@ -5,7 +5,7 @@
 ##############################################################################
 
 COOKBOOK_NAME="$(basename $0)"
-if [ -z "SHOESTRAP_BASE" ]; then
+if [ -z "$SHOESTRAP_BASE" ]; then
     DIR="$( cd "$( dirname "$0" )" && pwd )"
 else
     DIR="$SHOESTRAP_BASE"


### PR DESCRIPTION
Condition was always evaluating as false, and if SHOESTRAP_BASE was undefined
(as per default), recipes would not be found.
