### PR TITLE
Sanitize is_installed/set_installed arguments.

### DIFF
--- a/helpers/default
+++ b/helpers/default
@@ -331,12 +331,8 @@ fail_if_not_root () {
 # Checks if a certain element has already been installed.
 #
 function is_installed () {
-  if [ $# -gt 1 ]; then
-    local args=$*
-    local name=${args// /-}
-  else
-    local name=$1
-  fi
+  local args=$*
+  local name=${args//[ \/:@]/-}
 
   if [[ -f ~/.shoestrap/installed/$name ]]; then
     log "'$name' is already installed."
@@ -351,14 +347,9 @@ function is_installed () {
 # Sets an element as installed.
 #
 function set_installed () {
-  if [ $# -gt 1 ]; then
-    local args=$*
-    local name=${args// /-}
-  else
-    local name=$1
-  fi
+  local args=$*
+  local name=${args//[ \/:@]/-}
 
   mkdir -p ~/.shoestrap/installed
   touch ~/.shoestrap/installed/$name
 }
-


### PR DESCRIPTION
Using the is_installed/set_installed helpers with arguments that contain special characters (i.e github repositories, PPAs, anything with colons or dashes) will fail, because the concatenated arguments are not filename safe.

Also I think there is no need to distinguish between one or multiple arguments in the functions, it should be ok to just always sanitize.
