### PR TITLE
Set bash as default shell for created users.

### DIFF
--- a/helpers/default
+++ b/helpers/default
@@ -266,9 +266,9 @@ add_user () {
     [ "$pass" == "" ] && pass=generate_password
 
     if [[ "$args" != *nohome* ]]; then
-      /usr/sbin/useradd --password `openssl passwd -crypt $pass` --create-home $user
+      /usr/sbin/useradd --password `openssl passwd -crypt $pass` --create-home $user --shell /bin/bash
     else
-      /usr/sbin/useradd --password `openssl passwd -crypt $pass` $user
+      /usr/sbin/useradd --password `openssl passwd -crypt $pass` $user --shell /bin/bash
     fi
   fi
 }


### PR DESCRIPTION
Use bash as default shell for users, else it defaults to sh which doesn't work well with things like rbenv.
