### PR TITLE
Add support for cookbook specific recipes

### DIFF
--- a/helpers/default
+++ b/helpers/default
@@ -21,10 +21,16 @@ recipe () {
   CURRENT_RECIPE_NAME=$1
   DEFAULT_ASSETS_PATH="$DIR/assets/default/$CURRENT_RECIPE_NAME"
   COOKBOOK_ASSETS_PATH="$DIR/assets/$COOKBOOK_NAME/$CURRENT_RECIPE_NAME"
+  local cookbook_recipe="$DIR/recipes/$COOKBOOK_NAME/$CURRENT_RECIPE_NAME"
   local custom_recipe="$DIR/recipes/custom/$CURRENT_RECIPE_NAME"
   local default_recipe="$DIR/recipes/default/$CURRENT_RECIPE_NAME"
 
-  if [ -f $custom_recipe ]; then
+  if [ -f $cookbook_recipe ]; then
+    log "Running recipe '$cookbook_recipe'..." 1
+    separator
+    . $cookbook_recipe
+
+  elif [ -f $custom_recipe ]; then
     log "Running recipe '$custom_recipe'..." 1
     separator
     . $custom_recipe


### PR DESCRIPTION
In the `README.md` it is stated that cookbook specific recipes can be declared. They should be placed under:

```
[recipes]
  [cookbook1]          # Recipes for 'cookbook1'. Overrides anything in [default].
    recipe1
```

Unfortunately this did not work after I cloned the repo:

1) created a `recipes/my-cookbook/test` file with content `echo 'test'`
2) ran `sudo ./my-cookbook` in the root directory
3) received the error: `-> Could not find recipe for 'test'. Fail!`

So I took a look at `helpers/default` and it seems that the function `recipe()` lacks support for recipes under`$COOKBOOK_NAME`. I added this in this pull request.
